### PR TITLE
Remove `_IsMoveConstructible` from `__pattern_sort` impls

### DIFF
--- a/pstl/include/pstl/internal/algorithm_fwd.h
+++ b/pstl/include/pstl/internal/algorithm_fwd.h
@@ -724,15 +724,13 @@ __pattern_partition_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomA
 // sort
 //------------------------------------------------------------------------
 
-template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsMoveConstructible>
+template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 void
-__pattern_sort(_Tag, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _Compare,
-               _IsMoveConstructible) noexcept;
+__pattern_sort(_Tag, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _Compare) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 void
-__pattern_sort(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _Compare,
-               /*is_move_constructible=*/std::true_type);
+__pattern_sort(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _Compare);
 
 //------------------------------------------------------------------------
 // stable_sort

--- a/pstl/include/pstl/internal/algorithm_impl.h
+++ b/pstl/include/pstl/internal/algorithm_impl.h
@@ -2177,10 +2177,10 @@ __pattern_partition_copy(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __e
 // sort
 //------------------------------------------------------------------------
 
-template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsMoveConstructible>
+template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 void
-__pattern_sort(_Tag, _ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
-               _IsMoveConstructible) noexcept
+__pattern_sort(_Tag, _ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last,
+               _Compare __comp) noexcept
 {
     std::sort(__first, __last, __comp);
 }
@@ -2188,7 +2188,7 @@ __pattern_sort(_Tag, _ExecutionPolicy&&, _RandomAccessIterator __first, _RandomA
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 void
 __pattern_sort(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
-               _RandomAccessIterator __last, _Compare __comp, /*is_move_constructible=*/std::true_type)
+               _RandomAccessIterator __last, _Compare __comp)
 {
     using __backend_tag = typename decltype(__tag)::__backend_tag;
 

--- a/pstl/include/pstl/internal/glue_algorithm_impl.h
+++ b/pstl/include/pstl/internal/glue_algorithm_impl.h
@@ -606,7 +606,7 @@ sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIter
 
     typedef typename iterator_traits<_RandomAccessIterator>::value_type _InputType;
     return __pstl::__internal::__pattern_sort(__dispatch_tag, std::forward<_ExecutionPolicy>(__exec), __first, __last,
-                                              __comp, typename std::is_move_constructible<_InputType>::type());
+                                              __comp);
 }
 
 template <class _ExecutionPolicy, class _RandomAccessIterator>


### PR DESCRIPTION
In this PR we doing the next things:
- remove `_IsMoveConstructible` template param from `__pattern_sort` implementations as not required.

--------------------------------------------------------------------------------------------------------------------------
In this PR we synchronize changes from https://github.com/oneapi-src/oneDPL/pull/1599 with PSTL up-stream.